### PR TITLE
Support modern pytest and pytest-django

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 
 sudo: false
 
-cache: pip
 install: make requirements
 
 script:

--- a/pytest_django_ordering/plugin.py
+++ b/pytest_django_ordering/plugin.py
@@ -7,10 +7,19 @@ from pytest_django.plugin import validate_django_db
 
 def pytest_collection_modifyitems(items):
     def get_marker_transaction(test):
-        marker = test.get_marker('django_db')
+        try:
+            marker = test.get_closest_marker('django_db')
+        except AttributeError:
+            # pytest < 3.6.0
+            marker = test.get_marker('django_db')
+
         if marker:
             validate_django_db(marker)
-            return marker.transaction
+            try:
+                return marker.kwargs.get("transaction")
+            except AttributeError:
+                # pytest-django < 3.3.0
+                return marker.transaction
 
         return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-flake8==3.2.1
-pytest==3.0.6
+flake8
 -e .


### PR DESCRIPTION
This PR adds support for `pytest-django` versions `3.3.0` though `3.4.5` (the most recent available as of 1/23/19) and for `pytest` versions `3.6.0` through `4.1.1` (the most recent available as of 1/23/19).

It is backwards compatible.

I had to adjust the way the package requirements are specified, because  `pytest-django==3.3` dropped support for `pytest<3.6`, and it was proving very easy to get into a situation where incompatible versions of `pytest` and `pytest-django` were installed, especially when paired with the Travis cache. For example:
- `requirements.txt` specified `pytest==3.0.4`
- `setup.py` specified `pytest-django` without a version, which resolved to the latest, `3.4.5`, which requires `pytest>=3.6.0`.
- tests failed, even though this plugin works perfectly with `pytest<3.6.0` (so long as `pytest-django<3.3.0` is installed) and with `pytest>=3.6.0` (so long as `pytest-django>=3.3.0` is installed).

By removing `pytest` from requirements.txt, everything just works. If a user of `pytest-django-ordering` has `pytest-django` pinned to an old version (or, for testing purposes, if we pin it to an old version in `setup.py`), then pip will install an old, compatible version of `pytest`. Otherwise, it installs more recent, also mutually-compatible versions.

I tested with a variety of combinations, including:
- `pytest-django==3.2.1` paired with `pytest==3.0.6`
- `pytest-django==3.2.1` paired with `pytest==3.5.1`
- `pytest-django==3.30` paired with `pytest==3.6.0`
- `pytest-django==3.4.5` paired with `pytest==4.1.1`
-  and I think a few more in between.

Closes https://github.com/rlucioni/pytest-django-ordering/issues/3 and https://github.com/rlucioni/pytest-django-ordering/issues/4